### PR TITLE
Add client validation to Forgot Passowrd form

### DIFF
--- a/client/src/components/ForgotPasswordForm.tsx
+++ b/client/src/components/ForgotPasswordForm.tsx
@@ -1,13 +1,32 @@
+import { useForm } from 'react-hook-form';
+import z from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { ForgotPasswordSchema } from '@/lib/schema';
 import Button from './Button';
 import Input from './Input';
 
+type FormInput = z.infer<typeof ForgotPasswordSchema>;
+
 export default function ForgotPasswordForm() {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm({ resolver: zodResolver(ForgotPasswordSchema) });
+
+  function onSubmit(data: FormInput) {}
+
   return (
-    <form autoComplete="off" className="flex w-full flex-col gap-3">
+    <form
+      onSubmit={handleSubmit(onSubmit)}
+      autoComplete="off"
+      className="flex w-full flex-col gap-3"
+    >
       <Input
         label="Email address"
-        name="email"
+        {...register('email')}
         placeholder="Please enter your email"
+        error={errors.email?.message}
       />
       <Button color="black" type="submit">
         Reset Password

--- a/client/src/lib/schema.ts
+++ b/client/src/lib/schema.ts
@@ -33,3 +33,7 @@ export const SignInSchema = z.object({
     })
     .trim(),
 });
+
+export const ForgotPasswordSchema = z.object({
+  email: z.email({ message: 'Please enter a valid email.' }).trim(),
+});


### PR DESCRIPTION
## 📝 What’s changed
-Added client email validation to Frogot Password form.

## 🎯 Why
-The client validation of email will improve form and prevent from send unvalidated form.